### PR TITLE
Initial improvements

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* kconley@squareup.com lillianye@squareup.com manvita@squareup.com medley@squareup.com notenti@squareup.com onyekachukwu@squareup.com pojung@squareup.com tague@squareup.com

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ BINFMT_IMAGE=tonistiigi/binfmt:qemu-$(QEMU_VERSION)
 
 .PHONY: mkimage
 mkimage:
-	cd src/aports && git fetch --tags && git checkout $(GIT_TAG)
+	git submodule update --init --recursive && cd src/aports && git fetch --tags && git checkout $(GIT_TAG)
 	BUILDKIT_PROGRESS=plain $(DOCKER) build \
 		--no-cache \
 		--tag mkimage:$(ALPINE_VERSION)-$(ARCH) \

--- a/genapkovl-lima.sh
+++ b/genapkovl-lima.sh
@@ -114,7 +114,9 @@ if [ "${LIMA_INSTALL_LIMA_INIT}" == "true" ]; then
     cp /home/build/lima-init.sh "${tmp}/usr/bin/lima-init"
     cp /home/build/lima-network.awk "${tmp}/usr/bin/lima-network.awk"
 
+    echo dhclient >>"$tmp"/etc/apk/world
     echo e2fsprogs >>"$tmp"/etc/apk/world
+    echo iproute2 >>"$tmp"/etc/apk/world
     echo lsblk >>"$tmp"/etc/apk/world
     echo sfdisk >>"$tmp"/etc/apk/world
     echo shadow >>"$tmp"/etc/apk/world

--- a/lima-init.sh
+++ b/lima-init.sh
@@ -97,10 +97,10 @@ EOF
 
 # Add static nameservers to /etc/resolv.conf
 DNS=$(awk '/nameservers:/{flag=1; next} /^[^ ]/{flag=0} flag {gsub("^ +- +", ""); print}' \
-    "${LIMA_CIDATA_MNT}"/user-data | tr "\n" " ")
+    "${LIMA_CIDATA_MNT}"/user-data | tr --squeeze-repeats "\n" "\n" | paste -s -d ',' - | tr --delete "\n")
 
 if [ -n "${DNS}" ]; then
-    sed -i "/export dns/a dns=\"${DNS}\"" /usr/share/udhcpc/default.script
+    echo "prepend domain-name-servers ${DNS};" >> /etc/dhcp/dhclient.conf
 fi
 
 # Remove default CA certs

--- a/mkimg.lima.sh
+++ b/mkimg.lima.sh
@@ -9,7 +9,7 @@ profile_lima() {
     arch="aarch64 x86 x86_64"
     initfs_cmdline="modules=loop,squashfs,sd-mod,usb-storage"
     kernel_addons=
-    kernel_flavors="virt"
+    kernel_flavors="lts"
     kernel_cmdline="console=tty0 console=ttyS0,115200"
     syslinux_serial="0 115200"
     apkovl="genapkovl-lima.sh"

--- a/mkimg.lima.sh
+++ b/mkimg.lima.sh
@@ -44,7 +44,7 @@ profile_lima() {
         apks="$apks socat xz"
     fi
     if [ "${LIMA_INSTALL_LIMA_INIT}" == "true" ]; then
-        apks="$apks e2fsprogs lsblk sfdisk shadow sudo udev"
+        apks="$apks dhclient e2fsprogs iproute2 lsblk sfdisk shadow sudo udev"
     fi
     if [ "${LIMA_INSTALL_K3S}" == "true" ]; then
         apks="$apks k3s"


### PR DESCRIPTION
This PR:
* Changes the image build configuration to use the `lts` [kernel "flavor"](https://wiki.alpinelinux.org/wiki/Kernels) of Alpine Linux which pulls in the `vhci_hcd` kernel module we need to use USB/IP
* Switches the image from using [udhcpc](https://en.wikipedia.org/wiki/Udhcpc) as the DHCP client to instead use [dhclient](https://manpages.ubuntu.com/manpages/kinetic/man8/dhclient.8.html) as well as switched the iproute installation from being a minimal one provided by [BusyBox](https://en.wikipedia.org/wiki/BusyBox) to instead being provided by the [iproute2](https://en.wikipedia.org/wiki/Iproute2) project - this change is required to support our developers being able to connect to a Colima VM spun up from this image while being connected to our VPN
* Changes the build script to use [xz](https://en.wikipedia.org/wiki/XZ_Utils) to compress the resulting VM image ISO file to reduce its file size by about 30 MB
* Adds a `CODEOWNERS` file so members of my team will automatically be added as reviewers of PRs created for this repo (note [this won't take effect until the destination branch of the PR contains this file](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-file-location), i.e. after this PR merges)